### PR TITLE
[TASK-28] Extract dumb component app-task-field

### DIFF
--- a/src/app/membership/workday/task-field/task-field.dumb.component.html
+++ b/src/app/membership/workday/task-field/task-field.dumb.component.html
@@ -1,34 +1,32 @@
-<div class="card p-3 mb-3" [attr.data-testid]="`task-${index()}`">
-    <div class="d-flex align-items-center">
-        <select #taskType class="form-select w-auto me-3" (change)="updateTaskType(taskType.value)">
-            <option selected value="Get things done">⛳️</option>
-            <option value="Hit the target">🎯</option>
+<div class="d-flex align-items-center">
+    <select #taskType class="form-select w-auto me-3" (change)="updateTaskType(taskType.value)">
+        <option selected value="Get things done">⛳️</option>
+        <option value="Hit the target">🎯</option>
+    </select>
+    <input #taskTitle class="form-control flex-grow-1 fs-5 border-0" [value]="task().title"
+        (input)="updateTitle(taskTitle.value)" [attr.data-testid]="`task-input-${index()}`" />
+
+    <div class="d-flex align-items-center ms-3">
+        <select class="form-select w-auto me-3" #taskPomodoroCount
+            (change)="updatePomodoroCount(taskPomodoroCount.value) ">
+            <option selected value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
         </select>
-        <input #taskTitle class="form-control flex-grow-1 fs-5 border-0" [value]="task().title"
-            (input)="updateTitle(taskTitle.value)" [attr.data-testid]="`task-input-${index()}`" />
-
-        <div class="d-flex align-items-center ms-3">
-            <select class="form-select w-auto me-3" #taskPomodoroCount
-                (change)="updatePomodoroCount(taskPomodoroCount.value) ">
-                <option selected value="1">1</option>
-                <option value="2">2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
-            </select>
-            <button class="btn btn-sm">⏸</button>
-            <button class="btn btn-sm">⏸</button>
-            <button class="btn btn-sm">⏸</button>
-            <button class="btn btn-sm">⏸</button>
-            <button class="btn btn-sm">⏸</button>
-            <span class="mx-3 fs-5">0</span>
-            <span>🏁</span>
-        </div>
-
-        <button class="btn btn-link text-muted ms-3" [attr.data-testid]="`task-remove-${index()}`"
-            (click)="taskRemoved.emit()">
-            <i class="bi bi-x fs-4"></i>
-        </button>
-
+        <button class="btn btn-sm">⏸</button>
+        <button class="btn btn-sm">⏸</button>
+        <button class="btn btn-sm">⏸</button>
+        <button class="btn btn-sm">⏸</button>
+        <button class="btn btn-sm">⏸</button>
+        <span class="mx-3 fs-5">0</span>
+        <span>🏁</span>
     </div>
+
+    <button class="btn btn-link text-muted ms-3" [attr.data-testid]="`task-remove-${index()}`"
+        (click)="taskRemoved.emit()">
+        <i class="bi bi-x fs-4"></i>
+    </button>
+
 </div>

--- a/src/app/membership/workday/task-field/task-field.dumb.component.ts
+++ b/src/app/membership/workday/task-field/task-field.dumb.component.ts
@@ -12,6 +12,10 @@ import { PomodoroCount, Task, TaskType } from '../workday.page.store';
   templateUrl: './task-field.dumb.component.html',
   styleUrl: './task-field.dumb.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'card',
+    '[attr.data-testid]': '`task-${index()}`',
+  },
 })
 export class TaskFieldDumbComponent {
   readonly task = model.required<Task>();

--- a/src/app/membership/workday/workday.page.component.html
+++ b/src/app/membership/workday/workday.page.component.html
@@ -31,7 +31,7 @@
   @if($index === 3) {
   <h6 class="mb-3 text-muted">Tâches restantes</h6>
   }
-  <app-task-field [task]="task" [index]="$index" (taskUpdated)="store.updateTask($index, $event)"
+  <app-task-field class="p-3 mb-3" [task]="task" [index]="$index" (taskUpdated)="store.updateTask($index, $event)"
     (taskRemoved)="store.removeTask($index)" />
   }
 


### PR DESCRIPTION
## What this PR do ? 
- Extract dumb component `<app-task-field />` from page Workday.
- Use `host` attribute for dumb component app-task-field

<img width="349" height="176" alt="Capture d’écran 2025-10-24 à 06 43 43" src="https://github.com/user-attachments/assets/0b47e08e-ac80-4048-b8a6-52d8707bffd3" />

<img width="1538" height="782" alt="image" src="https://github.com/user-attachments/assets/8bdc3ade-7497-4991-811c-12a8eeacbcd4" />
